### PR TITLE
Build into Flatpak `stable` remote branch

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:daily
+      image: ghcr.io/elementary/flatpak-platform/runtime:6
       options: --privileged
 
     steps:
@@ -20,14 +20,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build
-        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master
         with:
-          bundle: org.gnome.evinceflatpak
+          bundle: evince.flatpak
           manifest-path: org.gnome.evince.json
+          run-tests: true
           repository-name: appcenter
           repository-url: https://flatpak.elementary.io/repo.flatpakrepo
           cache-key: "flatpak-builder-${{ github.sha }}"
-
+          branch: stable
+      
       - name: Deploy
         uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v3
         with:


### PR DESCRIPTION
Fixes #13 

Since all commits to main here are of releases, we probably don't need a separate release workflow yeah?