### PR TITLE
Flatpak: set runtime to platform instead of SDK

### DIFF
--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -1,6 +1,6 @@
 {
     "app-id" : "org.gnome.Evince",
-    "runtime" : "io.elementary.Sdk",
+    "runtime" : "io.elementary.Platform",
     "runtime-version" : "6",
     "sdk" : "io.elementary.Sdk",
     "command" : "evince",


### PR DESCRIPTION
We should be using the platform as the runtime, not the SDK with all the dev tools… plus it might save some space in the ISO.