### PR TITLE
Support dark style preference

### DIFF
--- a/dark-style.patch
+++ b/dark-style.patch
@@ -1,0 +1,86 @@
+diff --git a/meson.build b/meson.build
+index 72396a0..8a0fff1 100644
+--- a/meson.build
++++ b/meson.build
+@@ -155,6 +155,7 @@ gmodule_dep = dependency('gmodule-2.0')
+ gmodule_no_export_dep = dependency('gmodule-no-export-2.0', version: glib_req_version)
+ gtk_dep = dependency('gtk+-3.0', version: gtk_req_version)
+ gthread_dep = dependency('gthread-2.0', version: glib_req_version)
++granite_dep = dependency('granite')
+ hdy_dep = dependency('libhandy-1', version: hdy_req_version)
+ 
+ m_dep = cc.find_library('m')
+diff --git a/shell/ev-application.c b/shell/ev-application.c
+index c6f51c1..f103080 100644
+--- a/shell/ev-application.c
++++ b/shell/ev-application.c
+@@ -30,6 +30,7 @@
+ #include <glib/gi18n.h>
+ #include <glib/gstdio.h>
+ #include <gtk/gtk.h>
++#include <granite.h>
+ #include <libhandy-1/handy.h>
+ #ifdef GDK_WINDOWING_X11
+ #include <gdk/gdkx.h>
+@@ -176,7 +177,7 @@ ev_spawn (const char     *uri,
+ 
+ 	g_string_append_printf (cmd, " %s", path);
+ 	g_free (path);
+-	
++
+ 	/* Page label */
+ 	if (dest) {
+                 switch (ev_link_dest_get_dest_type (dest)) {
+@@ -940,6 +941,20 @@ ev_application_migrate_config_dir (EvApplication *application)
+         g_free (old_accels);
+ }
+ 
++static void
++ev_application_set_prefers_color_scheme ()
++{
++        GtkSettings* gtk_settings = gtk_settings_get_default ();
++        GraniteSettings* granite_settings = granite_settings_get_default ();
++
++        g_object_set (
++          gtk_settings,
++          "gtk-application-prefer-dark-theme",
++          granite_settings_get_prefers_color_scheme (granite_settings) == GRANITE_SETTINGS_COLOR_SCHEME_DARK,
++          NULL
++        );
++}
++
+ static void
+ ev_application_startup (GApplication *gapplication)
+ {
+@@ -992,6 +1007,7 @@ ev_application_startup (GApplication *gapplication)
+ 
+         EvApplication *application = EV_APPLICATION (gapplication);
+         const gchar **it;
++        GraniteSettings* granite_settings = granite_settings_get_default ();
+ 
+ 	g_application_set_resource_base_path (gapplication, "/org/gnome/evince");
+ 
+@@ -999,6 +1015,11 @@ ev_application_startup (GApplication *gapplication)
+ 
+         hdy_init ();
+ 
++        ev_application_set_prefers_color_scheme ();
++
++        g_signal_connect (granite_settings, "notify::prefers-color-scheme",
++          G_CALLBACK(ev_application_set_prefers_color_scheme), NULL);
++
+         for (it = action_accels; it[0]; it += g_strv_length ((gchar **)it) + 1)
+                 gtk_application_set_accels_for_action (GTK_APPLICATION (application), it[0], &it[1]);
+ }
+diff --git a/shell/meson.build b/shell/meson.build
+index 7cbc48f..a3089b1 100644
+--- a/shell/meson.build
++++ b/shell/meson.build
+@@ -52,6 +52,7 @@ sources += gnome.compile_resources(
+ deps = [
+   gdk_pixbuf_dep,
+   gnome_desktop_dep,
++  granite_dep,
+   hdy_dep,
+   libevmisc_dep,
+   libevproperties_dep,

--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -17,6 +17,7 @@
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.freedesktop.FileManager1",
+        "--system-talk-name=org.freedesktop.Accounts",
         "--own-name=org.gnome.evince",
         "--own-name=org.gnome.evince.Daemon",
         "--require-version=0.11.6"
@@ -163,14 +164,20 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Dnautilus=false",
-                "-Dthumbnailer=false"
+                "-Dthumbnailer=false",
+                "-Dgtk_doc=false",
+                "-Dintrospection=false"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evince/40/evince-40.1.tar.xz",
-                    "sha256": "7a666363c350af2e3bbba7f14b3c1befc5012f9ed3d9d073447f4c59f33dcf2d",
+                    "url": "https://download.gnome.org/sources/evince/40/evince-40.4.tar.xz",
+                    "sha256": "33420500e0e060f178a435063197d42dae7b67e39cc437a96510a33ddf7e95fb",
                     "git-init": true
+                },
+                {
+                    "type": "patch",
+                    "path": "dark-style.patch"
                 }
             ]
         }


### PR DESCRIPTION
Fixes #9 

Clean up a few extra things we don't need in the build and bump the version while we're here.

All of it looks good in dark style at first glance, but worth someone else giving it a once over.