### PR TITLE
Flatpak: Remove accountsservice hole

### DIFF
--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -17,7 +17,6 @@
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.freedesktop.FileManager1",
-        "--system-talk-name=org.freedesktop.Accounts",
         "--own-name=org.gnome.evince",
         "--own-name=org.gnome.evince.Daemon",
         "--require-version=0.11.6"


### PR DESCRIPTION
No longer needed because of new settings portal