### PR TITLE
Bump to 44.1

### DIFF
--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -1,34 +1,32 @@
 {
-    "app-id" : "org.gnome.Evince",
-    "runtime" : "io.elementary.Platform",
-    "runtime-version" : "7.1",
-    "sdk" : "io.elementary.Sdk",
-    "command" : "evince",
-    "copy-icon" : true,
-    "finish-args" : [
+    "id": "org.gnome.Evince",
+    "runtime": "io.elementary.Platform",
+    "runtime-version": "7.1",
+    "sdk": "io.elementary.Sdk",
+    "command": "evince",
+    "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--filesystem=host",
+        "--filesystem=home:ro",
+        "--filesystem=/media:ro",
+        "--filesystem=/run/media:ro",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
-        "--metadata=X-DConf=migrate-path=/org/gnome/evince/",
-        "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-run/gvfsd",
+        "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.freedesktop.FileManager1",
         "--own-name=org.gnome.evince",
         "--own-name=org.gnome.evince.Daemon",
         "--require-version=0.11.6"
     ],
-    "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
-        "env" : {
-            "V" : "1"
+    "build-options": {
+        "env": {
+            "V": "1"
         }
     },
-    "cleanup" : [
+    "cleanup": [
         "/include",
         "/lib/pkgconfig",
         "/share/pkgconfig",
@@ -41,7 +39,6 @@
         "*.a"
     ],
     "modules": [
-        "python3-gi-docgen-dependencies.json",
         {
             "name": "webp-pixbuf-loader",
             "buildsystem": "meson",
@@ -50,15 +47,15 @@
                     "GDK_PIXBUF_MODULEDIR": "/app/lib/evince/gdk-pixbuf/2.10.0/"
                 }
             },
-            "config-opts" : [
+            "config-opts": [
                 "-Dgdk_pixbuf_moduledir=/app/lib/evince/gdk-pixbuf/2.10.0/"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/aruiz/webp-pixbuf-loader.git",
-                    "commit": "1e1cad735784d16dd9b46d0415095d23029ab017",
-                    "tag": "0.0.6"
+                    "commit": "36b3df08af61887f3558e4d783e8710627a7a4b7",
+                    "tag": "0.2.2"
                 }
             ],
             "post-install": [
@@ -74,8 +71,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz",
-                    "sha256": "2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c",
+                    "url": "https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz",
+                    "sha256": "c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 3687,
@@ -105,9 +102,10 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-22.07.0.tar.xz",
-                    "sha256": "420230c5c43782e2151259b3e523e632f4861342aad70e7e20b8773d9eaf3428",
+                    "url": "https://poppler.freedesktop.org/poppler-23.03.0.tar.xz",
+                    "sha256": "b04148bf849c1965ada7eff6be4685130e3a18a84e0cce73bf9bc472ec32f2b4",
                     "x-checker-data": {
+                        "is-important": true,
                         "type": "anitya",
                         "project-id": 3686,
                         "url-template": "https://poppler.freedesktop.org/poppler-$version.tar.xz"
@@ -137,20 +135,25 @@
             ]
         },
         {
-            "name" : "libgxps",
-            "buildsystem" : "meson",
-            "config-opts" : [
+            "name": "libgxps",
+            "buildsystem": "meson",
+            "config-opts": [
                 "-Denable-test=false",
                 "-Ddisable-introspection=true"
             ],
-            "cleanup" : [
+            "cleanup": [
                 "/bin"
             ],
-            "sources" : [
+            "sources": [
                 {
-                    "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/libgxps/0.3/libgxps-0.3.2.tar.xz",
-                    "sha256" : "6d27867256a35ccf9b69253eb2a88a32baca3b97d5f4ef7f82e3667fa435251c"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libgxps/0.3/libgxps-0.3.2.tar.xz",
+                    "sha256": "6d27867256a35ccf9b69253eb2a88a32baca3b97d5f4ef7f82e3667fa435251c",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "stable-only": false,
+                        "name": "libgxps"
+                    }
                 }
             ]
         },
@@ -162,8 +165,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gspell/1.9/gspell-1.9.1.tar.xz",
-                    "sha256": "dcbb769dfdde8e3c0a8ed3102ce7e661abbf7ddf85df08b29915e92cd723abdd"
+                    "url": "https://download.gnome.org/sources/gspell/1.12/gspell-1.12.0.tar.xz",
+                    "sha256": "40d2850f1bb6e8775246fa1e39438b36caafbdbada1d28a19fa1ca07e1ff82ad",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gspell"
+                    }
                 }
             ]
         },
@@ -181,8 +188,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.4.tar.xz",
-                    "sha256": "1ce2c9d5067969dbe0b282ea5a9acfb8698751f03cd07e2c730240f85dc9ad25"
+                    "url": "https://download.gnome.org/sources/gnome-desktop/44/gnome-desktop-44.0.tar.xz",
+                    "sha256": "42c773745d84ba14bc1cf1c4c6f4606148803a5cd337941c63964795f3c59d42",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gnome-desktop"
+                    }
                 }
             ]
         },
@@ -192,16 +203,14 @@
             "config-opts": [
                 "-Dnautilus=false",
                 "-Dthumbnailer=false",
-                "-Dgtk_doc=true",
-                "-Dintrospection=true",
-                "-Duser_doc=false",
-                "-Ddevelopment=true"
+                "-Dgtk_doc=false"
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "tag": "44.1",
-                    "url": "https://gitlab.gnome.org/GNOME/evince.git"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/evince/44/evince-44.1.tar.xz",
+                    "sha256": "15afd3bb15ffb38fecab34c23350950ad270ab03a85b94e333d9dd7ee6a74314",
+                    "git-init": true,
                 }
             ],
             "cleanup": [

--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -13,6 +13,7 @@
         "--filesystem=/media:ro",
         "--filesystem=/run/media:ro",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
+        "--metadata=X-DConf=migrate-path=/org/gnome/evince/",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SessionManager",

--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -1,32 +1,34 @@
 {
-    "app-id": "org.gnome.Evince",
-    "runtime": "io.elementary.Platform",
-    "runtime-version": "7.1",
-    "sdk": "io.elementary.Sdk",
-    "command": "evince",
-    "finish-args": [
+    "app-id" : "org.gnome.Evince",
+    "runtime" : "io.elementary.Platform",
+    "runtime-version" : "7.1",
+    "sdk" : "io.elementary.Sdk",
+    "command" : "evince",
+    "copy-icon" : true,
+    "finish-args" : [
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
-        "--socket=cups",
         "--socket=pulseaudio",
         "--filesystem=host",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--metadata=X-DConf=migrate-path=/org/gnome/evince/",
-        "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",
+        "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.freedesktop.FileManager1",
         "--own-name=org.gnome.evince",
         "--own-name=org.gnome.evince.Daemon",
         "--require-version=0.11.6"
     ],
-    "build-options": {
-        "env": {
-            "V": "1"
+    "build-options" : {
+        "cflags" : "-O2 -g",
+        "cxxflags" : "-O2 -g",
+        "env" : {
+            "V" : "1"
         }
     },
-    "cleanup": [
+    "cleanup" : [
         "/include",
         "/lib/pkgconfig",
         "/share/pkgconfig",
@@ -39,6 +41,7 @@
         "*.a"
     ],
     "modules": [
+        "python3-gi-docgen-dependencies.json",
         {
             "name": "webp-pixbuf-loader",
             "buildsystem": "meson",
@@ -102,8 +105,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-22.11.0.tar.xz",
-                    "sha256": "093ba9844ed774285517361c15e21a31ba4df278a499263d4403cca74f2da828",
+                    "url": "https://poppler.freedesktop.org/poppler-22.07.0.tar.xz",
+                    "sha256": "420230c5c43782e2151259b3e523e632f4861342aad70e7e20b8773d9eaf3428",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 3686,
@@ -140,14 +143,14 @@
                 "-Denable-test=false",
                 "-Ddisable-introspection=true"
             ],
-            "cleanup": [
+            "cleanup" : [
                 "/bin"
             ],
-            "sources": [
+            "sources" : [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgxps/0.3/libgxps-0.3.2.tar.xz",
-                    "sha256": "6d27867256a35ccf9b69253eb2a88a32baca3b97d5f4ef7f82e3667fa435251c"
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/libgxps/0.3/libgxps-0.3.2.tar.xz",
+                    "sha256" : "6d27867256a35ccf9b69253eb2a88a32baca3b97d5f4ef7f82e3667fa435251c"
                 }
             ]
         },
@@ -178,8 +181,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/43/gnome-desktop-43.tar.xz",
-                    "sha256": "3d6e153317486157596aa3802f87676414c570738f450a94a041fe8835420a69"
+                    "url": "https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.4.tar.xz",
+                    "sha256": "1ce2c9d5067969dbe0b282ea5a9acfb8698751f03cd07e2c730240f85dc9ad25"
                 }
             ]
         },
@@ -189,13 +192,16 @@
             "config-opts": [
                 "-Dnautilus=false",
                 "-Dthumbnailer=false",
-                "-Dgtk_doc=false"
+                "-Dgtk_doc=true",
+                "-Dintrospection=true",
+                "-Duser_doc=false",
+                "-Ddevelopment=true"
             ],
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/evince.git",
-                    "tag": "43.1"
+                    "tag": "44.1",
+                    "url": "https://gitlab.gnome.org/GNOME/evince.git"
                 }
             ],
             "cleanup": [

--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -211,7 +211,7 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/evince/44/evince-44.1.tar.xz",
                     "sha256": "15afd3bb15ffb38fecab34c23350950ad270ab03a85b94e333d9dd7ee6a74314",
-                    "git-init": true,
+                    "git-init": true
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
Sync with https://github.com/flathub/org.gnome.Evince/blob/master/org.gnome.Evince.json

Still Gtk 3 so it doesn't require any Adw patches or anything :)

Todo:
- [x] Double check cups: https://github.com/elementary/evince/pull/19