### PR TITLE
Fix build warning

### DIFF
--- a/org.gnome.evince.json
+++ b/org.gnome.evince.json
@@ -188,10 +188,10 @@
             "sources": [
                 {
                     "type": "archive",
-                    "is-important": true,
                     "url": "https://download.gnome.org/sources/gnome-desktop/44/gnome-desktop-44.1.tar.xz",
                     "sha256": "ae7ca55dc9e08914999741523a17d29ce223915626bd2462a120bf96f47a79ab",
                     "x-checker-data": {
+                        "is-important": true,
                         "type": "gnome",
                         "name": "gnome-desktop"
                     }


### PR DESCRIPTION
Fix the 'Unknown property is-important for type BuilderSourceArchive' warning on build